### PR TITLE
fix error on musl

### DIFF
--- a/include/lsp-plug.in/plug-fw/wrap/common/libpath.h
+++ b/include/lsp-plug.in/plug-fw/wrap/common/libpath.h
@@ -241,7 +241,7 @@ namespace lsp
         // Open file for reading
         FILE *fd = fopen("/proc/self/maps", "r");
         if (fd == NULL)
-            return NULL;
+            return false;
 
         char *line      = NULL;
         ssize_t len     = 0;


### PR DESCRIPTION
If musl systems, if using C++ NULL is defined to be nullptr which produces an error if a bool is expected (as NULL won't be 0 any longer)