### PR TITLE
VST3 bundle metadata fixes

### DIFF
--- a/src/util/vst3_modinfo/vst3_modinfo.cpp
+++ b/src/util/vst3_modinfo/vst3_modinfo.cpp
@@ -222,7 +222,7 @@ namespace lsp
         {
             LSP_STATUS_ASSERT(os->write_ascii("\t<key>"));
             LSP_STATUS_ASSERT(os->write_ascii(key));
-            LSP_STATUS_ASSERT(os->writeln_ascii("<key>"));
+            LSP_STATUS_ASSERT(os->writeln_ascii("</key>"));
             return STATUS_OK;
         };
 
@@ -252,6 +252,7 @@ namespace lsp
             LSP_STATUS_ASSERT(os.writeln_ascii("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
             LSP_STATUS_ASSERT(os.writeln_ascii("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"));
             LSP_STATUS_ASSERT(os.writeln_ascii("<plist version=\"1.0\">"));
+            LSP_STATUS_ASSERT(os.writeln_ascii("<dict>"));
             {
                 // Generate version string
                 LSPString version;
@@ -293,6 +294,7 @@ namespace lsp
                 LSP_STATUS_ASSERT(write_key(&os, "NSHumanReadableCopyright"));
                 LSP_STATUS_ASSERT(write_escaped_string(&os, manifest->copyright));
             }
+            LSP_STATUS_ASSERT(os.writeln_ascii("</dict>"));
             LSP_STATUS_ASSERT(os.writeln_ascii("</plist>"));
 
             return STATUS_OK;
@@ -402,5 +404,4 @@ namespace lsp
         }
     } /* namespace vst3_modinfo */
 } /* namespace lsp */
-
 


### PR DESCRIPTION
The generated macOS VST3 bundle metadata is not valid plist XML. The helper writes `<key>name<key>` instead of `<key>name</key>` and emits keys directly under `<plist>` without the required root `<dict>`.

Some hosts and macOS bundle APIs rely on a valid plist when discovering or loading VST3 bundles. Invalid metadata makes host behavior fragile and can prevent otherwise valid plugin binaries from being loaded correctly.

## Changed Code

- `src/util/vst3_modinfo/vst3_modinfo.cpp`
  - Correct `write_key()` to emit `</key>`.
  - Add the required top-level `<dict>` around the generated key/value pairs.

## Reasoning

The plist format requires a single object under `<plist>`, and bundle metadata is conventionally a dictionary. The existing generator intended to write key/value pairs, so wrapping those pairs in `<dict>` preserves the existing data model while making the file valid.

The `write_key()` typo is a direct XML correctness bug. Fixing the close tag does not change semantics beyond making the already intended key names parseable.

Also refer to the VST3SDK samples:
public.sdk/samples/vst/again/mac/Info.plist
