### PR TITLE
[macos] Cocoa/AppKit view operations in main thread, parent attachment, teardown safety

### DIFF
--- a/include/lsp-plug.in/plug-fw/wrap/clap/impl/ui_wrapper.h
+++ b/include/lsp-plug.in/plug-fw/wrap/clap/impl/ui_wrapper.h
@@ -49,6 +49,7 @@ namespace lsp
             bRequestProcess = false;
             bUIActive       = false;
             bRealizeActive  = false;
+            bDestroying     = false;
 
         #ifdef LSP_CLAP_OWN_EVENT_LOOP
             pUIThread       = NULL;
@@ -84,7 +85,7 @@ namespace lsp
             pDisplay->slots()->bind(tk::SLOT_IDLE, slot_display_idle, this);
             pDisplay->set_idle_interval(1000 / UI_FRAMES_PER_SECOND);
 
-            // Lazy initialize the UI ONLY after whe have the parent/transient settings
+            // Initialize the UI early so gui.get_size() can report real dimensions.
             if ((res = initialize_ui()) != STATUS_OK)
                 return false;
 
@@ -98,6 +99,11 @@ namespace lsp
 
         void UIWrapper::do_destroy()
         {
+            if (bDestroying)
+                return;
+
+            bDestroying     = true;
+
             // Update UI status
             bUIActive       = false;
             if (pWrapper != NULL)
@@ -497,8 +503,10 @@ namespace lsp
 
         bool UIWrapper::accept_window_size(tk::Window *wnd, size_t width, size_t height)
         {
-            if ((pExt == NULL) || (wnd != wWindow))
+            if (wnd != wWindow)
                 return IWrapper::accept_window_size(wnd, width, height);
+            if ((bDestroying) || (pExt == NULL) || (pExt->gui == NULL))
+                return false;
 
             lsp_trace("request_resize(%d, %d)", int(width), int(height));
             nLastWidth  = width;
@@ -526,12 +534,17 @@ namespace lsp
         status_t UIWrapper::slot_ui_realized(tk::Widget *sender, void *ptr, void *data)
         {
             const ws::rectangle_t *r = static_cast<ws::rectangle_t *>(data);
+            UIWrapper *self     = static_cast<UIWrapper *>(ptr);
+            if ((self == NULL) || (self->bDestroying) || (r == NULL))
+                return STATUS_OK;
+            if ((self->pExt == NULL) || (self->pExt->gui == NULL))
+                return STATUS_OK;
+
         #ifdef LSP_TRACE
             lsp_trace("sender = %p, ptr = %p, data = %p", sender, ptr, data);
             lsp_trace("realized.w = %d, realized.h = %d", int(r->nWidth), int(r->nHeight));
         #endif /* LSP_TRACE */
 
-            UIWrapper *self     = static_cast<UIWrapper *>(ptr);
             if ((self->bRealizeActive) ||
                 ((self->nLastWidth == r->nWidth) && (self->nLastHeight == r->nHeight)))
                 return STATUS_OK;
@@ -551,7 +564,9 @@ namespace lsp
         {
             lsp_trace("sender = %p, ptr = %p, data = %p", sender, ptr, data);
             UIWrapper *this_ = static_cast<UIWrapper *>(ptr);
-            if (this_->pExt != NULL)
+            if ((this_ == NULL) || (this_->bDestroying))
+                return STATUS_OK;
+            if ((this_->pExt != NULL) && (this_->pExt->gui != NULL))
                 this_->pExt->gui->closed(this_->pExt->host, false);
             return STATUS_OK;
         }
@@ -586,11 +601,12 @@ namespace lsp
             if (wnd->visibility()->get())
             {
                 ws::rectangle_t rr;
+                rr.nLeft        = 0;
+                rr.nTop         = 0;
                 rr.nWidth       = 0;
                 rr.nHeight      = 0;
 
-                if (wnd->get_screen_rectangle(&rr) != STATUS_OK)
-                    return false;
+                wnd->get_padded_rectangle(&rr);
 
                 // Return result
                 nLastWidth      = rr.nWidth;
@@ -599,7 +615,7 @@ namespace lsp
             else
             {
                 ws::size_limit_t sr;
-                wnd->get_size_limits(&sr);
+                wnd->get_padded_size_limits(&sr);
 
                 // Return result
                 nLastWidth      = lsp_max(sr.nMinWidth, 32);
@@ -607,9 +623,9 @@ namespace lsp
             }
 
             if (width != NULL)
-                *width  = int(nLastWidth);
+                *width  = uint32_t(nLastWidth);
             if (height != NULL)
-                *height = int(nLastHeight);
+                *height = uint32_t(nLastHeight);
 
             lsp_trace("return width = %d, height = %d", int(nLastWidth), int(nLastHeight));
 
@@ -631,6 +647,9 @@ namespace lsp
 
         bool UIWrapper::get_resize_hints(clap_gui_resize_hints_t *hints)
         {
+            if (hints == NULL)
+                return false;
+
             tk::Window *wnd     = window();
             if (wnd == NULL)
                 return false;
@@ -655,6 +674,9 @@ namespace lsp
 
         bool UIWrapper::adjust_size(uint32_t *width, uint32_t *height)
         {
+            if ((width == NULL) || (height == NULL))
+                return false;
+
             tk::Window *wnd     = window();
             if (wnd == NULL)
                 return false;
@@ -666,23 +688,23 @@ namespace lsp
             ws::size_limit_t sr;
             wnd->get_padded_size_limits(&sr);
 
-            ws::rectangle_t r;
-            r.nLeft     = 0;
-            r.nTop      = 0;
-            r.nWidth    = *width;
-            r.nHeight   = *height;
+            ws::rectangle_t srq, drq;
+            srq.nLeft    = 0;
+            srq.nTop     = 0;
+            srq.nWidth   = *width;
+            srq.nHeight  = *height;
 
-            tk::SizeConstraints::apply(&r, &sr);
+            tk::SizeConstraints::apply(&drq, &srq, &sr);
 
             lsp_trace("adjust size width = %d -> %d, height = %d -> %d",
-                *width, int(r.nWidth),
-                *height, int(r.nHeight));
+                *width, int(drq.nWidth),
+                *height, int(drq.nHeight));
 
-            if ((r.nWidth > ssize_t(*width)) || (r.nHeight > ssize_t(*height)))
+            if ((drq.nWidth < 0) || (drq.nHeight < 0))
                 return false;
 
-            *width      = r.nWidth;
-            *height     = r.nHeight;
+            *width      = uint32_t(drq.nWidth);
+            *height     = uint32_t(drq.nHeight);
 
             return true;
         }
@@ -701,30 +723,31 @@ namespace lsp
             lsp_finally { sMutex.unlock(); };
 
             // Ensure that we can resize the window to the desired size
-            ws::rectangle_t r;
+            ws::rectangle_t srq, drq;
             ws::size_limit_t sr;
             wnd->get_padded_size_limits(&sr);
 
-            r.nLeft     = 0;
-            r.nTop      = 0;
-            r.nWidth    = width;
-            r.nHeight   = height;
+            srq.nLeft    = 0;
+            srq.nTop     = 0;
+            srq.nWidth   = width;
+            srq.nHeight  = height;
 
-            tk::SizeConstraints::apply(&r, &sr);
-            if ((r.nWidth > ssize_t(width)) || (r.nHeight > ssize_t(height)))
+            tk::SizeConstraints::apply(&drq, &srq, &sr);
+            if ((drq.nWidth != ssize_t(width)) || (drq.nHeight != ssize_t(height)))
             {
-//                lsp_trace("failed size check: r.nWidth=%d, width=%d, r.nHeight=%d, height=%d",
-//                    int(r.nWidth), int(width), int(r.nHeight), int(height));
+                lsp_trace("failed size check: width=%d -> %d, height=%d -> %d",
+                    int(width), int(drq.nWidth), int(height), int(drq.nHeight));
                 return false;
             }
 
             // Check that we need to resize window
-            wnd->get_padded_screen_rectangle(&r);
-            if ((r.nWidth != ssize_t(width)) && (r.nHeight != ssize_t(height)))
+            ws::rectangle_t r;
+            wnd->get_padded_rectangle(&r);
+            if ((r.nWidth != drq.nWidth) || (r.nHeight != drq.nHeight))
             {
                 lsp_trace("width = %d -> %d, height = %d -> %d, call for resize",
-                    int(width), int(r.nWidth), int(height), int(r.nHeight));
-                wnd->resize_window(width, height);
+                    int(r.nWidth), int(drq.nWidth), int(r.nHeight), int(drq.nHeight));
+                wnd->resize_window(drq.nWidth, drq.nHeight);
             }
 
             return true;
@@ -732,6 +755,9 @@ namespace lsp
 
         void *UIWrapper::to_native_handle(const clap_window_t *window)
         {
+            if (window == NULL)
+                return NULL;
+
         #if defined(PLATFORM_WINDOWS)
             return static_cast<void *>(window->win32);
         #elif defined(PLATFORM_MACOSX)
@@ -743,12 +769,23 @@ namespace lsp
 
         bool UIWrapper::set_parent(const clap_window_t *clap_window)
         {
+            if (clap_window == NULL)
+                return false;
+
             tk::Window * const wnd  = window();
             if (wnd == NULL)
                 return false;
 
+            if (!sMutex.lock())
+                return false;
+            lsp_finally { sMutex.unlock(); };
+
             status_t res = wnd->native()->set_parent(to_native_handle(clap_window));
-            return res == STATUS_OK;
+            if (res != STATUS_OK)
+                return false;
+
+            wnd->position()->set(0, 0);
+            return true;
         }
 
         bool UIWrapper::set_transient(const clap_window_t *window)
@@ -873,7 +910,8 @@ namespace lsp
                 lsp_trace("request_resize(%d, %d)", int(sr.nMinWidth), int(sr.nMinHeight));
                 nLastWidth  = sr.nMinWidth;
                 nLastHeight = sr.nMinHeight;
-                pExt->gui->request_resize(pExt->host, sr.nMinWidth, sr.nMinHeight);
+                if ((pExt != NULL) && (pExt->gui != NULL))
+                    pExt->gui->request_resize(pExt->host, sr.nMinWidth, sr.nMinHeight);
             }
 
             // Fetch preset state
@@ -919,7 +957,7 @@ namespace lsp
         status_t UIWrapper::slot_display_idle(tk::Widget *sender, void *ptr, void *data)
         {
             UIWrapper *self = static_cast<UIWrapper *>(ptr);
-            if (self != NULL)
+            if ((self != NULL) && (!self->bDestroying))
                 self->main_iteration();
 
             return STATUS_OK;

--- a/include/lsp-plug.in/plug-fw/wrap/clap/ui_wrapper.h
+++ b/include/lsp-plug.in/plug-fw/wrap/clap/ui_wrapper.h
@@ -37,9 +37,9 @@
 #include <lsp-plug.in/plug-fw/wrap/clap/wrapper.h>
 #include <lsp-plug.in/plug-fw/plug.h>
 
-#ifndef PLATFORM_WINDOWS
+#if (!defined(PLATFORM_WINDOWS)) && (!defined(PLATFORM_MACOSX))
     #define LSP_CLAP_OWN_EVENT_LOOP
-#endif /* PLATFORM_WINDOWS */
+#endif /* !PLATFORM_WINDOWS && !PLATFORM_MACOSX */
 
 namespace lsp
 {
@@ -60,6 +60,7 @@ namespace lsp
                 bool                            bRequestProcess;// Request the process() call flag
                 bool                            bUIActive;      // UI is active flag
                 bool                            bRealizeActive; // Realize is active
+                bool                            bDestroying;    // Destroy is active
 
             #ifdef LSP_CLAP_OWN_EVENT_LOOP
                 ipc::Thread                    *pUIThread;      // Thread that performs the UI event loop

--- a/src/wrap/clap.cpp
+++ b/src/wrap/clap.cpp
@@ -346,6 +346,12 @@ namespace lsp
 
         bool CLAP_ABI ui_get_size(const clap_plugin_t *plugin, uint32_t *width, uint32_t *height)
         {
+            if ((width == NULL) || (height == NULL))
+            {
+                lsp_trace("plugin = %p, width=%p, height=%p -> false", plugin, width, height);
+                return false;
+            }
+
             Wrapper *w = static_cast<Wrapper *>(plugin->plugin_data);
             UIWrapper *uw = w->ui_wrapper();
             const bool result = (uw != NULL) ? uw->get_size(width, height) : false;
@@ -353,7 +359,7 @@ namespace lsp
             {
                 lsp_trace("plugin = %p, width=%p, height=%p, UIWrapper=%p -> width=%d, height=%d",
                     plugin, width, height, uw, int(*width), int(*height));
-                return false;
+                return true;
             }
 
             lsp_trace("plugin = %p, width=%p, height=%p, UIWrapper=%p -> false", plugin, width, height, uw);
@@ -787,4 +793,3 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-


### PR DESCRIPTION
CLAP UIs in macOS hosts can fail to open, open at tiny sizes, hang, or crash on removal when parent attachment, size negotiation, event-loop ownership, and teardown are not aligned with CLAP host call order and Cocoa run-loop rules. 

This pull request preserves the existing CLAP GUI process order, but fixes sizing, parent attachment, macOS event-loop ownership, and teardown safety around it.

Apple’s Threading Programming Guide says AppKit event handling belongs to the main thread, and explicitly says NSView operations should be done only from the main thread. See “Event Handling Restrictions” and “NSView Restrictions”.

## Changed Code

- CLAP UI wrapper no longer starts its own UI event-loop thread on macOS.
- `ui_set_parent()` rejects null input, attaches the native toolkit window to the host parent view under the existing UI mutex, and resets toolkit position to `(0, 0)`.
- `UIWrapper::get_size()` now reports padded toolkit dimensions, and the exported CLAP dispatcher now returns that result to the host.
- `ui_get_size()` dispatcher now returns the wrapper result to the host and rejects null output pointers.
- `ui_adjust_size()` rejects null input, applies padded toolkit constraints, and writes the constrained size back to the host.
- `ui_set_size()` rejects sizes that violate constraints instead of silently accepting them, and resizes only to the accepted constrained size.
- Resize hints and native-window handle conversion now reject null inputs defensively.
- Destroy, close, realized, idle, show-time resize-request, and wrapper resize-request paths are guarded during teardown or missing host GUI extension state.

## Reasoning

CLAP hosts are allowed to call `get_size()` after clap_plugin_gui->create() and before set_parent()/show(). The current baseline already creates the UI during `create()`, and these changes preserve that behavior while making the reported and accepted sizes match the actual padded toolkit geometry.

Cocoa/AppKit view operations should run on the application main thread. In an embedded plugin, that means using the host’s AppKit event loop rather than starting a plugin-owned UI loop thread.

Destroy guards are needed because closing the toolkit window can emit callbacks while CLAP `gui.destroy()` is already in progress. The added null checks make the CLAP GUI API entry points fail cleanly when a host or callback supplies incomplete lifecycle state.

## References

* CLAP GUI lifecycle and main-thread annotations in CLAP SDK: `include/clap/ext/gui.h`
* AppKit event handling and NSView main-thread restrictions: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html
